### PR TITLE
SDK-488 get sdk name from env variable for node

### DIFF
--- a/node/api.js
+++ b/node/api.js
@@ -1,4 +1,4 @@
-const sdk = require('@ionos-cloud/sdk-nodejs')
+const sdk = require(process.env['IONOS_SDK_NAME'])
 
 const WAIT_FOR_REQUEST_OP = 'waitForRequest'
 

--- a/node/index.js
+++ b/node/index.js
@@ -1,4 +1,4 @@
-const sdk = require('@ionos-cloud/sdk-nodejs')
+const sdk = require(process.env['IONOS_SDK_NAME'])
 const output = require('./output')
 const payload = require('./payload')
 const api = require('./api')
@@ -7,6 +7,10 @@ const username = process.env['IONOS_USERNAME']
 const password = process.env['IONOS_PASSWORD']
 
 async function run() {
+  if (sdk === undefined) {
+    await output.error('IONOS_SDK_NAME env variable not found')
+  }
+  
   if (username === undefined) {
     await output.error('IONOS_USERNAME env variable not found')
   }


### PR DESCRIPTION
sdk was taken hardcoded. Now we need to have it parameterized. 
It seems IONOS_SDK_NAME can be used for this.