### PR TITLE
feat: java - add DBaaS support to sdk-test-driver

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 def sdkVersion = project.getProperties().get("sdkVersion")
-def sdkName = project.getProperties().get("sdkName")
+def sdkName    = project.getProperties().get("sdkName")
 
 dependencies {
     implementation "com.thoughtworks.paranamer:paranamer:2.8"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -25,12 +25,14 @@ repositories {
 }
 
 def sdkVersion = project.getProperties().get("sdkVersion")
+def sdkName = project.getProperties().get("sdkName")
 
 dependencies {
     implementation "com.thoughtworks.paranamer:paranamer:2.8"
-    implementation "com.ionoscloud:ionos-cloud-sdk:${sdkVersion}"
+    implementation "com.ionoscloud:${sdkName}:${sdkVersion}"
     implementation "org.reflections:reflections:0.9.11"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    implementation 'com.github.joschi.jackson:jackson-datatype-threetenbp:2.12.5'
     implementation 'org.apache.commons:commons-text:1.9'
 
     implementation 'org.hibernate.validator:hibernate-validator:7.0.1.Final'

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,1 +1,2 @@
 sdkVersion=5.1.1-SNAPSHOT
+sdkName=ionos-cloud-sdk


### PR DESCRIPTION
What does this fix?

- "basicAuth" header for DBaaS is different than the one used for cloudapi
- accept enums as case insensitive. enums for dbaas are not uppsercase.
- use value of enum to compare, as for dbaas we have enums that are de_txl(de/txl) - de/txl is not a valid enum name in java
- for infosVersionsGet we get an array, not a list. Add support for that
- get env variables from config
- gradle needs to get sdkName as a value, as we have different artifactids for DBaaS and cloudapi
- waitForRequest does not exist for dbaas, call using reflection
- offsetDateTime - add support to serialize correctly dates received as params

Tested for dbaas and cloudapi.