### PR TITLE
fix: nil check for apiResponse.Response

### DIFF
--- a/go/run.go
+++ b/go/run.go
@@ -283,7 +283,7 @@ func callMethod(name string, method reflect.Value, args []reflect.Value, params 
 	}
 
 	lowerCaseHeader := make(http.Header)
-	if apiResponse != nil {
+	if apiResponse != nil && apiResponse.Response != nil {
 		for key, value := range apiResponse.Header {
 			lowerCaseHeader[strings.ToLower(key)] = value
 		}


### PR DESCRIPTION
Nil check for apiResponse.Response. Crashes only on ci run.