### PR TITLE
fix: Add dependency for JAVA

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -32,6 +32,7 @@ def sdkArtifactId    = project.getProperties().get("sdkArtifactId")
 
 dependencies {
     implementation "com.thoughtworks.paranamer:paranamer:2.8"
+    implementation 'com.google.code.gson:gson:2.13.1'
     implementation "${sdkPackageName}:${sdkArtifactId}:${sdkVersion}"
     implementation 'org.reflections:reflections:0.9.11'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'


### PR DESCRIPTION
I observed this while working on Gradle/dependencies version upgrades for the SDK Java templates.

I generated an SDK using the new Gradle/dependencies versions and then I tried to run some tests but I received this error:
```
> Task :compileJava FAILED
/home/adeatcu/work/sdk-test-drivers/java/src/main/java/com/ionoscloud/services/SdkService.java:11: error: package com.google.gson does not exist
import com.google.gson.Gson;
                      ^
1 error
```
After adding the `implementation 'com.google.code.gson:gson:2.13.1'` in the `dependencies` list for `build.gradle`, the tests were running just fine.

I generated & tested again with the old Gradle/dependencies versions too and the tests were working fine, even though `implementation 'com.google.code.gson:gson:2.13.1'` was missing from `build.gradle` `dependencies` list. I'm not sure why they work, I expect to receive the same error that says that the package is missing, but for some reason, using the old Gradle versions this doesn't happen.